### PR TITLE
Fix byte and nibble colors

### DIFF
--- a/color.go
+++ b/color.go
@@ -32,7 +32,46 @@ const (
 // Color maps to the ANSI colors [0, 16) and the xterm colors [16, 256).
 type Color uint32
 
+var index2color = [256]Color{}
+
 // ANSI returns true if Color is within [0, 16).
 func (c Color) ANSI() bool {
 	return (c < 16)
+}
+func ColorFromIndex(i int) Color {
+	if index2color[0] == 0 {
+		generateIndex2Color()
+	}
+	return index2color[i]
+}
+
+func generateIndex2Color() {
+
+	// Predefined colors
+	predefinedColors := []uint32{
+		0x2e3436, 0xcc0000, 0x4e9a06, 0xc4a000, 0x3465a4, 0x75507b, 0x06989a,
+		0xd3d7cf, 0x555753, 0xef2929, 0x8ae234, 0xfce94f, 0x729fcf, 0xad7fa8,
+		0x34e2e2, 0xeeeeec,
+	}
+
+	for i, color := range predefinedColors {
+		index2color[i] = Color(color)
+	}
+
+	// Generate colors (16-231)
+	v := []uint32{0x00, 0x5f, 0x87, 0xaf, 0xd7, 0xff}
+	for i := 0; i < 216; i++ {
+		r := v[(i/36)%6]
+		g := v[(i/6)%6]
+		b := v[i%6]
+		rgb := (r << 16) | (g << 8) | b
+		index2color[16+i] = Color(rgb)
+	}
+
+	// Generate greys (232-255)
+	for i := 0; i < 24; i++ {
+		c := uint32(8 + i*10)
+		rgb := (c << 16) | (c << 8) | c
+		index2color[232+i] = Color(rgb)
+	}
 }

--- a/color.go
+++ b/color.go
@@ -39,7 +39,7 @@ func (c Color) ANSI() bool {
 	return (c < 16)
 }
 
-// byte2color maps an 8 bit color to a 24-bit RGB Color.
+// byte2color maps an 8 bit color to a 24 bit RGB Color.
 func byte2color(i int) Color {
 	if colorCache[0] == 0 {
 		loadColorCache()

--- a/color.go
+++ b/color.go
@@ -29,33 +29,33 @@ const (
 	DefaultCursor
 )
 
+var colorCache = [256]Color{}
+
 // Color maps to the ANSI colors [0, 16) and the xterm colors [16, 256).
 type Color uint32
-
-var index2color = [256]Color{}
 
 // ANSI returns true if Color is within [0, 16).
 func (c Color) ANSI() bool {
 	return (c < 16)
 }
-func ColorFromIndex(i int) Color {
-	if index2color[0] == 0 {
-		generateIndex2Color()
+
+// byte2color maps an 8 bit color to a 24-bit RGB Color.
+func byte2color(i int) Color {
+	if colorCache[0] == 0 {
+		loadColorCache()
 	}
-	return index2color[i]
+	return colorCache[i]
 }
 
-func generateIndex2Color() {
+func loadColorCache() {
 
-	// Predefined colors
-	predefinedColors := []uint32{
+	predefinedColors := []Color{
 		0x2e3436, 0xcc0000, 0x4e9a06, 0xc4a000, 0x3465a4, 0x75507b, 0x06989a,
 		0xd3d7cf, 0x555753, 0xef2929, 0x8ae234, 0xfce94f, 0x729fcf, 0xad7fa8,
-		0x34e2e2, 0xeeeeec,
-	}
+		0x34e2e2, 0xeeeeec}
 
 	for i, color := range predefinedColors {
-		index2color[i] = Color(color)
+		colorCache[i] = color
 	}
 
 	// Generate colors (16-231)
@@ -65,13 +65,13 @@ func generateIndex2Color() {
 		g := v[(i/6)%6]
 		b := v[i%6]
 		rgb := (r << 16) | (g << 8) | b
-		index2color[16+i] = Color(rgb)
+		colorCache[16+i] = Color(rgb)
 	}
 
 	// Generate greys (232-255)
 	for i := 0; i < 24; i++ {
 		c := uint32(8 + i*10)
 		rgb := (c << 16) | (c << 8) | c
-		index2color[232+i] = Color(rgb)
+		colorCache[232+i] = Color(rgb)
 	}
 }

--- a/color_test.go
+++ b/color_test.go
@@ -1,0 +1,24 @@
+package vt10x
+
+import (
+	"testing"
+)
+
+func TestByte2Color(t *testing.T) {
+	color := byte2color(0)
+	if color != 0x2e3436 {
+		t.Fatal(color)
+	}
+	color = byte2color(15)
+	if color != 0xeeeeec {
+		t.Fatal(color)
+	}
+	color = byte2color(16)
+	if color != 0x000000 {
+		t.Fatal(color)
+	}
+	color = byte2color(231)
+	if color != 0xffffff {
+		t.Fatal(color)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/tuzig/vt10x
+module github.com/hinshun/vt10x
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/hinshun/vt10x
+module github.com/tuzig/vt10x
 
 go 1.14

--- a/state.go
+++ b/state.go
@@ -638,7 +638,7 @@ func (t *State) setAttr(attr []int) {
 			if i+2 < len(attr) && attr[i+1] == 5 {
 				i += 2
 				if between(attr[i], 0, 255) {
-					t.cur.Attr.FG = Color(attr[i])
+					t.cur.Attr.FG = ColorFromIndex(attr[i])
 				} else {
 					t.logf("bad fgcolor %d\n", attr[i])
 				}
@@ -659,7 +659,7 @@ func (t *State) setAttr(attr []int) {
 			if i+2 < len(attr) && attr[i+1] == 5 {
 				i += 2
 				if between(attr[i], 0, 255) {
-					t.cur.Attr.BG = Color(attr[i])
+					t.cur.Attr.BG = ColorFromIndex(attr[i])
 				} else {
 					t.logf("bad bgcolor %d\n", attr[i])
 				}
@@ -678,13 +678,13 @@ func (t *State) setAttr(attr []int) {
 			t.cur.Attr.BG = DefaultBG
 		default:
 			if between(a, 30, 37) {
-				t.cur.Attr.FG = Color(a - 30)
+				t.cur.Attr.FG = ColorFromIndex(a - 30)
 			} else if between(a, 40, 47) {
-				t.cur.Attr.BG = Color(a - 40)
+				t.cur.Attr.BG = ColorFromIndex(a - 40)
 			} else if between(a, 90, 97) {
-				t.cur.Attr.FG = Color(a - 90 + 8)
+				t.cur.Attr.FG = ColorFromIndex(a - 90 + 8)
 			} else if between(a, 100, 107) {
-				t.cur.Attr.BG = Color(a - 100 + 8)
+				t.cur.Attr.BG = ColorFromIndex(a - 100 + 8)
 			} else {
 				t.logf("gfx attr %d unknown\n", a)
 			}

--- a/state.go
+++ b/state.go
@@ -638,7 +638,7 @@ func (t *State) setAttr(attr []int) {
 			if i+2 < len(attr) && attr[i+1] == 5 {
 				i += 2
 				if between(attr[i], 0, 255) {
-					t.cur.Attr.FG = ColorFromIndex(attr[i])
+					t.cur.Attr.FG = byte2color(attr[i])
 				} else {
 					t.logf("bad fgcolor %d\n", attr[i])
 				}
@@ -659,7 +659,7 @@ func (t *State) setAttr(attr []int) {
 			if i+2 < len(attr) && attr[i+1] == 5 {
 				i += 2
 				if between(attr[i], 0, 255) {
-					t.cur.Attr.BG = ColorFromIndex(attr[i])
+					t.cur.Attr.BG = byte2color(attr[i])
 				} else {
 					t.logf("bad bgcolor %d\n", attr[i])
 				}
@@ -678,13 +678,13 @@ func (t *State) setAttr(attr []int) {
 			t.cur.Attr.BG = DefaultBG
 		default:
 			if between(a, 30, 37) {
-				t.cur.Attr.FG = ColorFromIndex(a - 30)
+				t.cur.Attr.FG = byte2color(a - 30)
 			} else if between(a, 40, 47) {
-				t.cur.Attr.BG = ColorFromIndex(a - 40)
+				t.cur.Attr.BG = byte2color(a - 40)
 			} else if between(a, 90, 97) {
-				t.cur.Attr.FG = ColorFromIndex(a - 90 + 8)
+				t.cur.Attr.FG = byte2color(a - 90 + 8)
 			} else if between(a, 100, 107) {
-				t.cur.Attr.BG = ColorFromIndex(a - 100 + 8)
+				t.cur.Attr.BG = byte2color(a - 100 + 8)
 			} else {
 				t.logf("gfx attr %d unknown\n", a)
 			}

--- a/vt_test.go
+++ b/vt_test.go
@@ -62,3 +62,16 @@ func TestNewline(t *testing.T) {
 		t.Fatal(st.cur.X, st.cur.Y, attr.FG, attr.BG)
 	}
 }
+
+func TestIndexColor(t *testing.T) {
+	term := New()
+	_, err := term.Write([]byte("\033[30mA"))
+	if err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
+	attr := term.Cell(0, 0)
+	// The predefined color index 0 is:
+	if attr.FG != 0x2e3436 {
+		t.Fatal(attr.FG)
+	}
+}


### PR DESCRIPTION
When working in true colors, some programs, like lsd, still use 256 byte colors. Thesecolors were stored in the cell as a 0-255 value which are all blue. This change translate the 4 & 8 bit color values to their RGB value before updating cells.